### PR TITLE
Elastic search adapter

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,8 +29,46 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     strategy:
+      fail-fast: false
       matrix:
-        php-version: [8.1, 8.2]
+        php:
+          - '8.2'
+        db:
+          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql5.7", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:14", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+        include:
+          - php: '8.1'
+            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - php: '8.1'
+            db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - php: '8.2'
+            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - php: '8.2'
+            db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+    env:
+      PHP_VERSION: '${{ matrix.php }}'
+      DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'
+      db_dsn: '${{ fromJson(matrix.db).dsn }}'
+
+    services:
+      db:
+        image: '${{ fromJson(matrix.db).image }}'
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_USER: 'bedita'
+          MYSQL_PASSWORD: 'bedita'
+          MYSQL_DATABASE: 'bedita'
+
+          POSTGRES_USER: 'bedita'
+          POSTGRES_PASSWORD: 'bedita'
+          POSTGRES_DB: 'bedita'
+        ports:
+          - '3306:3306'
+          - '5432:5432'
+        options: '${{ fromJson(matrix.db).options }}'
 
     steps:
       - name: 'Checkout current revision'
@@ -42,9 +80,9 @@ jobs:
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'
         with:
-          php-version: '${{ matrix.php-version }}'
+          php-version: '${{ matrix.php }}'
           tools: 'composer:v2'
-          extensions: 'mbstring, intl, pdo_mysql.pdo'
+          extensions: 'mbstring, intl, pdo_${{ fromJson(matrix.db).pdo }}'
           coverage: 'pcov'
           ini-values: 'pcov.directory=., pcov.exclude="~vendor~"'
 
@@ -56,9 +94,9 @@ jobs:
         uses: 'actions/cache@v3'
         with:
           path: '${{ steps.cachedir.outputs.path }}'
-          key: "composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}"
+          key: "composer-${{ matrix.php }}-${{ hashFiles('**/composer.json') }}"
           restore-keys: |
-            composer-${{ matrix.php-version }}-
+            composer-${{ matrix.php }}-
             composer-
 
       - name: 'Install dependencies with Composer'
@@ -79,5 +117,5 @@ jobs:
       - name: 'Archive code coverage results'
         uses: 'actions/upload-artifact@v3'
         with:
-          name: 'PHP ${{ matrix.php }}'
+          name: 'PHP ${{ matrix.php }} with ${{ fromJson(matrix.db).vendor }}'
           path: 'clover.xml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,21 @@ name: Release
 on:
   pull_request_target:
     types: [closed]
-
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Release type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - patch
+        - minor
+        - major
 jobs:
   release-job:
     uses: bedita/github-workflows/.github/workflows/release.yml@v1
     with:
       main_branch: 'main'
       dist_branches: '["main"]'
+      version_bump: ${{ inputs.releaseType }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 Icon?
 ehthumbs.db
 Thumbs.db
+/tmp

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": "^8.1",
         "cakephp/cakephp": "^4.4.1",
-        "cakephp/elastic-search": "^3.4"
+        "cakephp/elastic-search": "^3.4",
+        "bedita/core": "^5.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "cakephp/cakephp": "^4.4.1",
         "cakephp/elastic-search": "^3.4",
-        "bedita/core": "dev-feat/v5/search-adapters"
+        "bedita/core": "dev-refactor/v5/use-search-adapters"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "autoload-dev": {
         "psr-4": {
             "BEdita\\ElasticSearch\\Test\\": "tests/",
+            "BEdita\\Core\\Test\\": "vendor/bedita/core/tests/",
             "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "cakephp/cakephp": "^4.4.1",
         "cakephp/elastic-search": "^3.4",
-        "bedita/core": "^5.13"
+        "bedita/core": "dev-feat/v5/search-adapters"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
     "autoload-dev": {
         "psr-4": {
             "BEdita\\ElasticSearch\\Test\\": "tests/",
-            "BEdita\\Core\\Test\\": "vendor/bedita/core/tests/",
-            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/",
+            "BEdita\\Core\\Test\\": "vendor/bedita/core/tests/"
         }
     },
     "scripts": {
@@ -56,6 +56,7 @@
     "prefer-stable": true,
     "config": {
         "allow-plugins": {
+            "cakephp/plugin-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,3 +5,7 @@ parameters:
     - src
     - tests
   level: 9
+  ignoreErrors:
+    - "#Method [a-zA-Z0-9\\_\\\\:\\(\\)]+ has parameter \\$[a-zA-Z0-9_]+ with no value type specified in iterable type array#"
+    - "#Method [a-zA-Z0-9\\_\\\\:\\(\\)]+ return type has no value type specified in iterable type array#"
+    - "#Property [a-zA-Z0-9\\$\\_\\\\:\\(\\)]+ type has no value type specified in iterable type array#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,4 +4,4 @@ parameters:
   paths:
     - src
     - tests
-  level: 5
+  level: 9

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,4 +4,4 @@ parameters:
   paths:
     - src
     - tests
-  level: 9
+  level: 5

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,4 @@ parameters:
     - src
     - tests
   level: 9
-  ignoreErrors:
-    - "#Method [a-zA-Z0-9\\_\\\\:\\(\\)]+ has parameter \\$[a-zA-Z0-9_]+ with no value type specified in iterable type array#"
-    - "#Method [a-zA-Z0-9\\_\\\\:\\(\\)]+ return type has no value type specified in iterable type array#"
-    - "#Property [a-zA-Z0-9\\$\\_\\\\:\\(\\)]+ type has no value type specified in iterable type array#"
+  checkMissingIterableValueType: false

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -11,6 +11,7 @@ use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Exception;
 use Psr\Log\LogLevel;
 
 class ElasticSearchAdapter extends BaseAdapter
@@ -120,12 +121,12 @@ class ElasticSearchAdapter extends BaseAdapter
         try {
             // Execute SQL to create table. In MySQL the transaction is completely useless,
             // because `CREATE TABLE` implicitly implies a commit.
-            $connection->transactional(function (Connection $connection) use ($schema) {
+            $connection->transactional(function (Connection $connection) use ($schema): void {
                 foreach ($schema->createSql($connection) as $statement) {
                     $connection->execute($statement);
                 }
             });
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->log($e, LogLevel::CRITICAL);
 
             return null;

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -25,7 +25,7 @@ class ElasticSearchAdapter extends BaseAdapter
     /**
      * @inheritDoc
      */
-    public function search(Query $query, string $text, array $options = [], array $config = []): Query
+    public function search(Query $query, string $text, array $options = []): Query
     {
         return $this->buildQuery($query, $text, $options);
     }

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -81,6 +81,7 @@ class ElasticSearchAdapter extends BaseAdapter
         return $query
             ->innerJoin(
                 $tempTable->getTable(),
+                // @phpstan-ignore-next-line
                 fn (QueryExpression $exp): QueryExpression => $exp->equalFields(
                     $tempTable->aliasField('id'),
                     $query->getRepository()->aliasField('id'),
@@ -139,7 +140,7 @@ class ElasticSearchAdapter extends BaseAdapter
         } catch (Exception $e) {
             $this->log(sprintf('Could not create temporary table for ElasticSearch results: %s', $e), LogLevel::ERROR);
 
-            throw new RuntimeException('Could not create temporary table for ElasticSearch results', $e);
+            throw new RuntimeException('Could not create temporary table for ElasticSearch results', 0, $e);
         }
 
         return (new Table(compact('connection', 'table', 'schema')))

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -1,0 +1,134 @@
+<?php
+namespace BEdita\ElasticSearch\Adapter;
+
+use BEdita\Core\Search\BaseAdapter;
+use Cake\Database\Expression\ComparisonExpression;
+use Cake\ORM\Query;
+use Cake\Datasource\EntityInterface;
+
+class ElasticSearchAdapter extends BaseAdapter
+{
+    /**
+     * @inheritDoc
+     */
+    public function search(Query $query, string $text, array $options = [], array $config = []): Query
+    {
+        return $query;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function indexResource(EntityInterface $entity, string $operation): void
+    {
+    }
+
+    /**
+     * Build elastic search query
+     */
+    protected function buildElasticSearchQuery(array $options): array
+    {
+        return ['todo'];
+    }
+
+    /**
+     * Build query and return it
+     *
+     * @param Query $query The query
+     * @param array $options The options
+     * @return Query
+     */
+    protected function buildQuery(Query $query, array $options): Query
+    {
+        $results = $this->buildElasticSearchQuery($options);
+
+        if (count($results) === 0) {
+            // Nothing found. No results should be returned. Add a contradiction to the `WHERE` clause.
+            return $query->where(new ComparisonExpression(1, 1, 'integer', '<>'));
+        }
+
+        // TODO: implement this
+        return $query;
+
+        // // Prepare temporary table with `id` and `score` from ElasticSearch results.
+        // $tempTable = sprintf('elasticsearch_%s', sha1($this->compiledQuery));
+        // $tempTable = $this->createTempTable($tempTable);
+        // $insertQuery = $tempTable->query()->insert(['id', 'score']);
+        // foreach ($results as $row) {
+        //     $insertQuery = $insertQuery->values($row);
+        // }
+        // $insertQuery->execute();
+
+        // // Add a join with the temporary table to filter by ID and sort by relevance score.
+        // return $query
+        //     ->innerJoin(
+        //         $tempTable->getTable(),
+        //         new ComparisonExpression(
+        //             new IdentifierExpression($tempTable->aliasField('id')),
+        //             new IdentifierExpression($this->getTable()->aliasField('id')),
+        //             'integer',
+        //             '='
+        //         )
+        //     )
+        //     ->orderDesc($tempTable->aliasField('score'));
+    }
+
+    // /**
+    //  * Create a temporary table to store search results.
+    //  *
+    //  * @param string $table Temporary table name.
+    //  * @return \Cake\ORM\Table|null
+    //  */
+    // protected function createTempTable($table)
+    // {
+    //     // $connection = $this->getTable()->getConnection();
+    //     // $schema = (new TableSchema($table))
+    //     //     ->setTemporary(true)
+    //     //     ->addColumn('id', [
+    //     //         'type' => TableSchema::TYPE_INTEGER,
+    //     //         'length' => 11,
+    //     //         'unsigned' => true,
+    //     //         'null' => false,
+    //     //     ])
+    //     //     ->addColumn('score', [
+    //     //         'type' => TableSchema::TYPE_FLOAT,
+    //     //         'null' => false,
+    //     //     ])
+    //     //     ->addConstraint(
+    //     //         'PRIMARY',
+    //     //         [
+    //     //             'type' => TableSchema::CONSTRAINT_PRIMARY,
+    //     //             'columns' => ['id'],
+    //     //         ]
+    //     //     )
+    //     //     ->addIndex(
+    //     //         sprintf('%s_score_idx', str_replace('_', '', $table)),
+    //     //         [
+    //     //             'type' => TableSchema::INDEX_INDEX,
+    //     //             'columns' => ['score'],
+    //     //         ]
+    //     //     );
+
+    //     // try {
+    //     //     // Execute SQL to create table. In MySQL the transaction is completely useless,
+    //     //     // because `CREATE TABLE` implicitly implies a commit.
+    //     //     $connection->transactional(function (Connection $connection) use ($schema) {
+    //     //         foreach ($schema->createSql($connection) as $statement) {
+    //     //             $connection->execute($statement);
+    //     //         }
+    //     //     });
+    //     // } catch (\Exception $e) {
+    //     //     $this->log($e, LogLevel::CRITICAL);
+
+    //     //     return null;
+    //     // }
+
+    //     // $table = (new Table(compact('connection', 'table', 'schema')))
+    //     //     ->setPrimaryKey('id')
+    //     //     ->setDisplayField('score');
+
+    //     // return $table;
+    // }
+}

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace BEdita\ElasticSearch\Adapter;
 
 use BEdita\Core\Search\BaseAdapter;
@@ -127,15 +129,13 @@ class ElasticSearchAdapter extends BaseAdapter
                 }
             });
         } catch (Exception $e) {
-            $this->log($e, LogLevel::CRITICAL);
+            $this->log($e->getMessage(), LogLevel::CRITICAL);
 
             return null;
         }
 
-        $table = (new Table(compact('connection', 'table', 'schema')))
+        return (new Table(compact('connection', 'table', 'schema')))
             ->setPrimaryKey('id')
             ->setDisplayField('score');
-
-        return $table;
     }
 }

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -3,8 +3,8 @@ namespace BEdita\ElasticSearch\Adapter;
 
 use BEdita\Core\Search\BaseAdapter;
 use Cake\Database\Expression\ComparisonExpression;
-use Cake\ORM\Query;
 use Cake\Datasource\EntityInterface;
+use Cake\ORM\Query;
 
 class ElasticSearchAdapter extends BaseAdapter
 {
@@ -36,9 +36,9 @@ class ElasticSearchAdapter extends BaseAdapter
     /**
      * Build query and return it
      *
-     * @param Query $query The query
+     * @param \Cake\ORM\Query $query The query
      * @param array $options The options
-     * @return Query
+     * @return \Cake\ORM\Query
      */
     protected function buildQuery(Query $query, array $options): Query
     {

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -61,7 +61,7 @@ class ElasticSearchAdapter extends BaseAdapter
         }
 
         // Prepare temporary table with `id` and `score` from ElasticSearch results.
-        $tempTable = $this->createTempTable();
+        $tempTable = $this->createTempTable($query->getConnection());
         $insertQuery = $tempTable->query()->insert(['id', 'score']);
         foreach ($results as $row) {
             $insertQuery = $insertQuery->values($row);
@@ -85,12 +85,12 @@ class ElasticSearchAdapter extends BaseAdapter
     /**
      * Create a temporary table to store search results.
      *
+     * @param \Cake\Database\Connection $connection The database connection
      * @return \Cake\ORM\Table|null
      */
-    protected function createTempTable(): ?Table
+    protected function createTempTable(Connection $connection): ?Table
     {
         $table = sprintf('elasticsearch_%s', time());
-        $connection = $this->fetchTable()->getConnection();
         $schema = (new TableSchema($table))
             ->setTemporary(true)
             ->addColumn('id', [

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -82,7 +82,7 @@ class ElasticSearchAdapter extends BaseAdapter
                 $tempTable->getTable(),
                 new ComparisonExpression(
                     new IdentifierExpression($tempTable->aliasField('id')),
-                    new IdentifierExpression($this->fetchTable('objects')->aliasField('id')),
+                    new IdentifierExpression($query->getRepository()->aliasField('id')),
                     'integer',
                     '='
                 )

--- a/tests/Fixture/ObjectTypesFixture.php
+++ b/tests/Fixture/ObjectTypesFixture.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ElasticSearch\Test\Fixture;
+
+use BEdita\Core\Test\Fixture\ObjectTypesFixture as BEditaObjectTypesFixture;
+
+/**
+ * Fixture for object types.
+ */
+class ObjectTypesFixture extends BEditaObjectTypesFixture
+{
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        // 1
+        [
+            'singular' => 'object',
+            'name' => 'objects',
+            'is_abstract' => true,
+            'parent_id' => null,
+            'tree_left' => 1,
+            'tree_right' => 20,
+            'description' => null,
+            'plugin' => 'BEdita/Core',
+            'model' => 'Objects',
+            'created' => '2017-11-10 09:27:23',
+            'modified' => '2017-11-10 09:27:23',
+            'enabled' => true,
+            'core_type' => true,
+        ],
+        // 2
+        [
+            'singular' => 'user',
+            'name' => 'users',
+            'is_abstract' => false,
+            'parent_id' => 1,
+            'tree_left' => 2,
+            'tree_right' => 3,
+            'description' => null,
+            'plugin' => 'BEdita/Core',
+            'model' => 'Users',
+            'hidden' => '["birthdate","body","company","company_name","company_kind","deathdate","description","national_id_number","person_title","publish_end","publish_start","state_name","vat_number","website"]',
+            'created' => '2017-11-10 09:27:23',
+            'modified' => '2017-11-10 09:27:23',
+            'enabled' => true,
+            'core_type' => true,
+        ],
+        // 3
+        [
+            'singular' => 'classroom',
+            'name' => 'classrooms',
+            'is_abstract' => false,
+            'parent_id' => 1,
+            'tree_left' => 4,
+            'tree_right' => 5,
+            'description' => null,
+            'plugin' => 'Zanichelli/Classrooms',
+            'model' => 'Classrooms',
+            'hidden' => '["body","description","translations"]',
+            'created' => '2020-12-10 17:30:00',
+            'modified' => '2020-12-10 17:30:00',
+            'enabled' => true,
+            'core_type' => false,
+        ],
+        // 4
+        [
+            'singular' => 'message',
+            'name' => 'messages',
+            'is_abstract' => false,
+            'parent_id' => 1,
+            'tree_left' => 6,
+            'tree_right' => 7,
+            'description' => null,
+            'plugin' => 'Zanichelli/Classrooms',
+            'model' => 'Messages',
+            'hidden' => '["description","translations"]',
+            'created' => '2020-12-10 17:30:00',
+            'modified' => '2020-12-10 17:30:00',
+            'enabled' => true,
+            'core_type' => false,
+        ],
+        // 5
+        [
+            'singular' => 'link',
+            'name' => 'links',
+            'is_abstract' => false,
+            'parent_id' => 1,
+            'tree_left' => 8,
+            'tree_right' => 9,
+            'description' => null,
+            'plugin' => 'BEdita/Core',
+            'model' => 'Links',
+            'created' => '2020-12-10 17:30:00',
+            'modified' => '2020-12-10 17:30:00',
+            'enabled' => true,
+            'core_type' => true,
+        ],
+    ];
+}

--- a/tests/Fixture/ObjectsFixture.php
+++ b/tests/Fixture/ObjectsFixture.php
@@ -1,0 +1,146 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ElasticSearch\Test\Fixture;
+
+use BEdita\Core\Test\Fixture\ObjectsFixture as BEditaObjectsFixture;
+
+/**
+ * Fixture for objects.
+ */
+class ObjectsFixture extends BEditaObjectsFixture
+{
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        // 1
+        [
+            'object_type_id' => 2, // users
+            'status' => 'on',
+            'uname' => 'admin-user',
+            'locked' => 1,
+            'deleted' => 0,
+            'created' => '2020-12-10 17:30:00',
+            'modified' => '2020-12-10 17:30:00',
+            'published' => null,
+            'title' => 'Mr. Admin',
+            'description' => null,
+            'body' => null,
+            'extra' => null,
+            'lang' => 'en',
+            'created_by' => 1,
+            'modified_by' => 1,
+        ],
+        // 2
+        [
+            'object_type_id' => 2, // users
+            'status' => 'on',
+            'uname' => 'myz_1',
+            'locked' => 0,
+            'deleted' => 0,
+            'created' => '2020-12-10 17:30:00',
+            'modified' => '2020-12-10 17:30:00',
+            'published' => null,
+            'title' => 'Test Docente',
+            'description' => null,
+            'body' => null,
+            'extra' => null,
+            'lang' => 'it',
+            'created_by' => 1,
+            'modified_by' => 1,
+        ],
+        // 3
+        [
+            'object_type_id' => 2, // users
+            'status' => 'on',
+            'uname' => 'myz_2',
+            'locked' => 0,
+            'deleted' => 0,
+            'created' => '2020-12-10 17:30:00',
+            'modified' => '2020-12-10 17:30:00',
+            'published' => null,
+            'title' => 'Test Studente',
+            'description' => null,
+            'body' => null,
+            'extra' => null,
+            'lang' => 'it',
+            'created_by' => 1,
+            'modified_by' => 1,
+        ],
+        // 4
+        [
+            'object_type_id' => 2, // users
+            'status' => 'on',
+            'uname' => 'myz_3',
+            'locked' => 0,
+            'deleted' => 0,
+            'created' => '2020-12-10 17:30:00',
+            'modified' => '2020-12-10 17:30:00',
+            'published' => null,
+            'title' => 'Test Docente Universitario',
+            'description' => null,
+            'body' => null,
+            'extra' => null,
+            'lang' => 'it',
+            'created_by' => 1,
+            'modified_by' => 1,
+        ],
+        // 5
+        [
+            'object_type_id' => 2, // users
+            'status' => 'on',
+            'uname' => 'myz_4',
+            'locked' => 0,
+            'deleted' => 0,
+            'created' => '2020-12-10 17:30:00',
+            'modified' => '2020-12-10 17:30:00',
+            'published' => null,
+            'title' => 'Test Studente Universitario',
+            'description' => null,
+            'body' => null,
+            'extra' => null,
+            'lang' => 'it',
+            'created_by' => 1,
+            'modified_by' => 1,
+        ],
+        // 6
+        [
+            'object_type_id' => 3, // classrooms
+            'status' => 'on',
+            'uname' => 'classrooms-one',
+            'locked' => 0,
+            'deleted' => 0,
+            'created' => '2020-12-22 12:31:00',
+            'modified' => '2020-12-22 12:31:00',
+            'published' => null,
+            'title' => '',
+            'description' => null,
+            'body' => null,
+            'extra' => null,
+            'lang' => 'it',
+            'created_by' => 2,
+            'modified_by' => 2,
+        ],
+        // 7
+        [
+            'object_type_id' => 4, // messages
+            'status' => 'on',
+            'uname' => 'message-one',
+            'locked' => 0,
+            'deleted' => 0,
+            'created' => '2020-12-22 12:31:00',
+            'modified' => '2020-12-22 12:31:00',
+            'published' => null,
+            'title' => '',
+            'description' => null,
+            'body' => 'Ragazzi, questo è un messaggio.',
+            'extra' => null,
+            'lang' => 'it',
+            'created_by' => 2,
+            'modified_by' => 2,
+        ],
+    ];
+}

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -20,9 +20,7 @@ use ReflectionClass;
 class ElasticSearchAdapterTest extends TestCase
 {
     /**
-     * Test fixtures
-     *
-     * @var array
+     * @inheritDoc
      */
     protected $fixtures = [
         'plugin.BEdita/Core.Objects',

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -38,8 +38,9 @@ class ElasticSearchAdapterTest extends TestCase
         $reflectionClass = new ReflectionClass(ElasticSearchAdapter::class);
         $method = $reflectionClass->getMethod('buildElasticSearchQuery');
         $method->setAccessible(true);
+        $text = 'searchme';
         $options = [];
-        $actual = $method->invokeArgs(new ElasticSearchAdapter(), [$options]);
+        $actual = $method->invokeArgs(new ElasticSearchAdapter(), [$text, $options]);
         $expected = [];
         static::assertEquals($expected, $actual);
     }
@@ -91,6 +92,28 @@ class ElasticSearchAdapterTest extends TestCase
     }
 
     /**
+     * Test `search` method with mock for elastic search
+     *
+     * @return void
+     * @covers ::search()
+     * @covers ::buildQuery()
+     * @covers ::buildElasticSearchQuery()
+     * @covers ::createTempTable()
+     */
+    public function testSearchMockElastic(): void
+    {
+        $adapter = $this->createPartialMock(ElasticSearchAdapter::class, ['buildElasticSearchQuery']);
+        $adapter->method('buildElasticSearchQuery')->willReturn([
+            ['id' => 1, 'score' => 1.0],
+            ['id' => 2, 'score' => 0.5],
+        ]);
+        $query = $this->fetchTable('objects')->find()->where(['id' => 1]);
+        $text = 'searchme';
+        $actual = $adapter->search($query, $text, [], []);
+        static::assertInstanceOf(Query::class, $actual);
+    }
+
+    /**
      * Test `createTempTable` method
      *
      * @return void
@@ -98,6 +121,7 @@ class ElasticSearchAdapterTest extends TestCase
      */
     public function testCreateTempTable(): void
     {
+        sleep(1);
         $reflectionClass = new ReflectionClass(ElasticSearchAdapter::class);
         $method = $reflectionClass->getMethod('createTempTable');
         $method->setAccessible(true);

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -122,9 +122,9 @@ class ElasticSearchAdapterTest extends TestCase
         $query = $this->fetchTable('objects')->find()->where(['id' => 1]);
         $text = 'searchme';
         $actual = $adapter->search($query, $text, []);
-        $partialSql = 'SELECT objects.id AS objects__id, objects.object_type_id AS objects__object_type_id, objects.status AS objects__status, objects.uname AS objects__uname, objects.locked AS objects__locked, objects.created AS objects__created, objects.modified AS objects__modified, objects.published AS objects__published, objects.title AS objects__title, objects.description AS objects__description, objects.body AS objects__body, objects.extra AS objects__extra, objects.lang AS objects__lang, objects.created_by AS objects__created_by, objects.modified_by AS objects__modified_by, objects.publish_start AS objects__publish_start, objects.publish_end AS objects__publish_end, objects.deleted AS objects__deleted, objects.custom_props AS objects__custom_props FROM objects objects INNER JOIN elasticsearch_';
+        $partialSql = 'SELECT objects.id AS objects__id';
         static::assertInstanceOf(Query::class, $actual);
-        static::assertTrue(strpos($actual->sql(), $partialSql) === 0);
+        static::assertTrue(str_starts_with($actual->sql(), $partialSql));
     }
 
     /**

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -20,6 +20,16 @@ use ReflectionClass;
 class ElasticSearchAdapterTest extends TestCase
 {
     /**
+     * Test fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.ObjectTypes',
+    ];
+
+    /**
      * Test `buildElasticSearchQuery` method
      *
      * @return void

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -111,7 +111,6 @@ class ElasticSearchAdapterTest extends TestCase
     public function testSearchMockElastic(): void
     {
         $adapter = new class extends ElasticSearchAdapter {
-            // @phpstan-ignore-next-line
             protected function buildElasticSearchQuery(string $text, array $options): array
             {
                 return [

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -70,7 +70,6 @@ class ElasticSearchAdapterTest extends TestCase
                 $query,
                 'text',
                 [],
-                [],
             ],
         ];
     }
@@ -82,7 +81,6 @@ class ElasticSearchAdapterTest extends TestCase
      * @param Query $query
      * @param string $text
      * @param array $options
-     * @param array $config
      * @return void
      * @covers ::search()
      * @covers ::buildQuery()
@@ -93,11 +91,10 @@ class ElasticSearchAdapterTest extends TestCase
         string $expected,
         Query $query,
         string $text,
-        array $options = [],
-        array $config = []
+        array $options = []
     ): void {
         $adapter = new ElasticSearchAdapter();
-        $actual = $adapter->search($query, $text, $options, $config);
+        $actual = $adapter->search($query, $text, $options);
         static::assertInstanceOf($expected, $actual);
     }
 
@@ -119,7 +116,7 @@ class ElasticSearchAdapterTest extends TestCase
         ]);
         $query = $this->fetchTable('objects')->find()->where(['id' => 1]);
         $text = 'searchme';
-        $actual = $adapter->search($query, $text, [], []);
+        $actual = $adapter->search($query, $text, []);
         static::assertInstanceOf(Query::class, $actual);
     }
 

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -13,23 +13,14 @@ use Cake\TestSuite\TestCase;
 class ElasticSearchAdapterTest extends TestCase
 {
     /**
-     * Fixtures
-     *
-     * @var array
-     */
-    protected $fixtures = [
-        'ObjectsFixture',
-    ];
-
-    /**
      * Test `buildElasticSearchQuery` method
      *
      * @return void
      * @covers ::buildElasticSearchQuery()
      */
-    public function testBuildElasticSearchQueryWithSingleTerm(): void
+    public function testBuildElasticSearchQuery(): void
     {
-        $reflectionClass = new \ReflectionClass(ElasticSearchAdapter::class);
+        $reflectionClass = new \ReflectionClass(ElasticSearchAdapter::class);// @phan-suppress-current-line
         $method = $reflectionClass->getMethod('buildElasticSearchQuery');
         $method->setAccessible(true);
         $options = [];

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -9,6 +9,7 @@ use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use ReflectionClass;
 
@@ -26,6 +27,15 @@ class ElasticSearchAdapterTest extends TestCase
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.Objects',
     ];
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        TableRegistry::getTableLocator()->clear();
+        parent::setUp();
+    }
 
     /**
      * Test `buildElasticSearchQuery` method

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace BEdita\ElasticSearch\Test\TestCase\Adapter;
 
 use BEdita\ElasticSearch\Adapter\ElasticSearchAdapter;

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -111,6 +111,7 @@ class ElasticSearchAdapterTest extends TestCase
     public function testSearchMockElastic(): void
     {
         $adapter = new class extends ElasticSearchAdapter {
+            // @phpstan-ignore-next-line
             protected function buildElasticSearchQuery(string $text, array $options): array
             {
                 return [
@@ -141,8 +142,9 @@ class ElasticSearchAdapterTest extends TestCase
                 return parent::createTempTable($connection);
             }
         };
-
-        $table = $adapter->createTempTable(ConnectionManager::get('test'));
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $table = $adapter->createTempTable($connection);
         // The type of `$table` is trivial, perform assertions on created columns or such, if necessary.
         static::assertInstanceOf(Table::class, $table);
         static::assertSame(

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -13,9 +13,9 @@ use Cake\TestSuite\TestCase;
 use ReflectionClass;
 
 /**
- * {@see BEdita\Core\Command\ElasticSearchAdapter} Test Case
+ * {@see BEdita\ElasticSearch\Adapter\ElasticSearchAdapter} Test Case
  *
- * @coversDefaultClass \BEdita\Core\Command\ElasticSearchAdapter
+ * @coversDefaultClass \BEdita\ElasticSearch\Adapter\ElasticSearchAdapter
  */
 class ElasticSearchAdapterTest extends TestCase
 {

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -100,34 +100,6 @@ class ElasticSearchAdapterTest extends TestCase
     }
 
     /**
-     * Test `search` method with mock for elastic search
-     *
-     * @return void
-     * @covers ::search()
-     * @covers ::buildQuery()
-     * @covers ::buildElasticSearchQuery()
-     * @covers ::createTempTable()
-     */
-    public function testSearchMockElastic(): void
-    {
-        $adapter = new class extends ElasticSearchAdapter {
-            protected function buildElasticSearchQuery(string $text, array $options): array
-            {
-                return [
-                    ['id' => 1, 'score' => 1.0],
-                    ['id' => 2, 'score' => 0.5],
-                ];
-            }
-        };
-        $query = $this->fetchTable('objects')->find()->where(['id' => 1]);
-        $text = 'searchme';
-        $actual = $adapter->search($query, $text, []);
-        $partialSql = 'SELECT objects.id AS objects__id';
-        static::assertInstanceOf(Query::class, $actual);
-        static::assertTrue(str_starts_with($actual->sql(), $partialSql));
-    }
-
-    /**
      * Test `search` with elastic search
      *
      * @return void

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -23,8 +23,8 @@ class ElasticSearchAdapterTest extends TestCase
      * @inheritDoc
      */
     protected $fixtures = [
-        'plugin.BEdita/Core.Objects',
         'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Objects',
     ];
 
     /**

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -122,6 +122,34 @@ class ElasticSearchAdapterTest extends TestCase
         $query = $this->fetchTable('objects')->find()->where(['id' => 1]);
         $text = 'searchme';
         $actual = $adapter->search($query, $text, []);
+        $partialSql = 'SELECT objects.id AS objects__id, objects.object_type_id AS objects__object_type_id, objects.status AS objects__status, objects.uname AS objects__uname, objects.locked AS objects__locked, objects.created AS objects__created, objects.modified AS objects__modified, objects.published AS objects__published, objects.title AS objects__title, objects.description AS objects__description, objects.body AS objects__body, objects.extra AS objects__extra, objects.lang AS objects__lang, objects.created_by AS objects__created_by, objects.modified_by AS objects__modified_by, objects.publish_start AS objects__publish_start, objects.publish_end AS objects__publish_end, objects.deleted AS objects__deleted, objects.custom_props AS objects__custom_props FROM objects objects INNER JOIN elasticsearch_';
+        static::assertInstanceOf(Query::class, $actual);
+        static::assertTrue(strpos($actual->sql(), $partialSql) === 0);
+    }
+
+    /**
+     * Test `search` with elastic search
+     *
+     * @return void
+     * @covers ::search()
+     * @covers ::buildQuery()
+     * @covers ::buildElasticSearchQuery()
+     * @covers ::createTempTable()
+     */
+    public function testSearchElastic(): void
+    {
+        $adapter = new class extends ElasticSearchAdapter {
+            protected function buildElasticSearchQuery(string $text, array $options): array
+            {
+                return [
+                    ['id' => 1, 'score' => 1.0],
+                    ['id' => 2, 'score' => 0.5],
+                ];
+            }
+        };
+        $query = $this->fetchTable('objects')->find()->where(['id' => 1]);
+        $text = 'searchme';
+        $actual = $adapter->search($query, $text, []);
         static::assertInstanceOf(Query::class, $actual);
         static::markTestIncomplete('This test has not been implemented yet.');
     }

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -59,11 +59,11 @@ class ElasticSearchAdapterTest extends TestCase
     /**
      * Test `search` method
      *
+     * @param string $expected
      * @param Query $query
      * @param string $text
      * @param array $options
      * @param array $config
-     * @param string $expected
      * @return void
      * @covers ::search()
      * @covers ::buildQuery()

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -111,7 +111,8 @@ class ElasticSearchAdapterTest extends TestCase
     public function testSearchMockElastic(): void
     {
         $adapter = new class extends ElasticSearchAdapter {
-            protected function buildElasticSearchQuery(string $text, array $options): array {
+            protected function buildElasticSearchQuery(string $text, array $options): array
+            {
                 return [
                     ['id' => 1, 'score' => 1.0],
                     ['id' => 2, 'score' => 0.5],

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -4,6 +4,7 @@ namespace BEdita\ElasticSearch\Test\TestCase\Adapter;
 use BEdita\ElasticSearch\Adapter\ElasticSearchAdapter;
 use Cake\ORM\Query;
 use Cake\TestSuite\TestCase;
+use ReflectionClass;
 
 /**
  * {@see BEdita\Core\Command\ElasticSearchAdapter} Test Case
@@ -20,7 +21,7 @@ class ElasticSearchAdapterTest extends TestCase
      */
     public function testBuildElasticSearchQuery(): void
     {
-        $reflectionClass = new \ReflectionClass(ElasticSearchAdapter::class);// @phan-suppress-current-line
+        $reflectionClass = new ReflectionClass(ElasticSearchAdapter::class);
         $method = $reflectionClass->getMethod('buildElasticSearchQuery');
         $method->setAccessible(true);
         $options = [];

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace BEdita\ElasticSearch\Test\TestCase\Adapter;
+
+use BEdita\ElasticSearch\Adapter\ElasticSearchAdapter;
+use Cake\ORM\Query;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see BEdita\Core\Command\ElasticSearchAdapter} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\ElasticSearchAdapter
+ */
+class ElasticSearchAdapterTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'ObjectsFixture',
+    ];
+
+    /**
+     * Test `buildElasticSearchQuery` method
+     *
+     * @return void
+     * @covers ::buildElasticSearchQuery()
+     */
+    public function testBuildElasticSearchQueryWithSingleTerm(): void
+    {
+        $reflectionClass = new \ReflectionClass(ElasticSearchAdapter::class);
+        $method = $reflectionClass->getMethod('buildElasticSearchQuery');
+        $method->setAccessible(true);
+        $options = [];
+        $actual = $method->invokeArgs(new ElasticSearchAdapter(), [$options]);
+        $expected = ['todo'];
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `buildElasticSearchQuery` method
+     *
+     * @return array
+     */
+    public function searchProvider(): array
+    {
+        $query = $this->fetchTable('objects')->find()->where(['id' => 1]);
+
+        return [
+            'query' => [
+                Query::class,
+                $query,
+                'text',
+                [],
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * Test `search` method
+     *
+     * @param Query $query
+     * @param string $text
+     * @param array $options
+     * @param array $config
+     * @param string $expected
+     * @return void
+     * @covers ::search()
+     * @dataProvider searchProvider()
+     */
+    public function testSearch(
+        string $expected,
+        Query $query,
+        string $text,
+        array $options = [],
+        array $config = []
+    ): void {
+        $adapter = new ElasticSearchAdapter();
+        $actual = $adapter->search($query, $text, $options, $config);
+        static::assertInstanceOf($expected, $actual);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,8 +7,6 @@ use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
-use Cake\I18n\FrozenDate;
-use Cake\I18n\FrozenTime;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Security;
 use Migrations\TestSuite\Migrator;
@@ -75,18 +73,6 @@ if (!TableRegistry::getTableLocator() instanceof TableLocator) {
     TableRegistry::setTableLocator(new TableLocator());
 }
 
-$now = FrozenTime::parse('2023-06-26T00:00:00Z');
-FrozenTime::setTestNow($now);
-FrozenDate::setTestNow($now);
-
-// Fixate sessionid early on, as php7.2+
-// does not allow the sessionid to be set after stdout
-// has been written to.
-//session_id('cli');
-
-//TypeFactory::map('jsonobject', JsonObjectType::class);
-
-//Router::reload();
 Security::setSalt('YlAPGwItcN6msaiuej76a6uyasdNTn3ikcO');
 
 (new Migrator())->runMany([

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,16 +56,20 @@ Cache::setConfig([
         'className' => 'Null',
     ],
 ]);
-
-ConnectionManager::setConfig('test', [
-    'className' => Connection::class,
-    'driver' => Sqlite::class,
-    'database' => dirname(__DIR__) . DS . 'tmp' . DS . 'test.sqlite',
-    'encoding' => 'utf8',
-    'cacheMetadata' => true,
-    'quoteIdentifiers' => false,
-]);
-ConnectionManager::alias('test', 'default');
+if (getenv('db_dsn')) {
+    ConnectionManager::drop('test');
+    ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
+} else {
+    ConnectionManager::setConfig('test', [
+        'className' => Connection::class,
+        'driver' => Sqlite::class,
+        'database' => dirname(__DIR__) . DS . 'tmp' . DS . 'test.sqlite',
+        'encoding' => 'utf8',
+        'cacheMetadata' => true,
+        'quoteIdentifiers' => false,
+    ]);
+    ConnectionManager::alias('test', 'default');
+}
 
 if (!TableRegistry::getTableLocator() instanceof TableLocator) {
     TableRegistry::setTableLocator(new TableLocator());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,9 +8,6 @@ use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
-if (file_exists($root . '/config/bootstrap.php')) {
-    require $root . '/config/bootstrap.php';
-}
 
 ConnectionManager::setConfig('test', [
     'className' => Connection::class,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,12 @@
 <?php
 declare(strict_types=1);
 
+use BEdita\Core\ORM\Locator\TableLocator;
+use Cake\Database\Connection;
+use Cake\Database\Driver\Sqlite;
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\TableRegistry;
+
 /**
  * Test suite bootstrap for ElasticSearch.
  *
@@ -35,4 +41,23 @@ require_once $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';
+}
+
+// DebugKit skips settings these connection config if PHP SAPI is CLI / PHPDBG.
+// But since PagesControllerTest is run with debug enabled and DebugKit is loaded
+// in application, without setting up these config DebugKit errors out.
+ConnectionManager::setConfig('test_debug_kit', [
+    'className' => Connection::class,
+    'driver' => Sqlite::class,
+    'database' => dirname(__DIR__) . DS . 'tmp' . DS . 'debug_kit.sqlite',
+    'encoding' => 'utf8',
+    'cacheMetadata' => true,
+    'quoteIdentifiers' => false,
+]);
+
+ConnectionManager::alias('test', 'default');
+ConnectionManager::alias('test_debug_kit', 'debug_kit');
+
+if (!TableRegistry::getTableLocator() instanceof TableLocator) {
+    TableRegistry::setTableLocator(new TableLocator());
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use BEdita\Core\ORM\Locator\TableLocator;
+use Cake\Cache\Cache;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
@@ -22,3 +23,4 @@ ConnectionManager::alias('test', 'default');
 if (!TableRegistry::getTableLocator() instanceof TableLocator) {
     TableRegistry::setTableLocator(new TableLocator());
 }
+Cache::disable();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,14 +6,56 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
-use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
 use Cake\I18n\FrozenDate;
 use Cake\I18n\FrozenTime;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Security;
 use Migrations\TestSuite\Migrator;
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+$findRoot = function ($root) {
+    do {
+        $lastRoot = $root;
+        $root = dirname($root);
+        if (is_dir($root . '/vendor/cakephp/cakephp')) {
+            return $root;
+        }
+    } while ($root !== $lastRoot);
+    throw new Exception('Cannot find the root of the application, unable to run tests');
+};
+$root = $findRoot(__FILE__);
+unset($findRoot);
+chdir($root);
+
+require_once 'vendor/cakephp/cakephp/src/basics.php';
+require_once 'vendor/autoload.php';
+
+define('ROOT', $root . DS . 'tests' . DS . 'test_app' . DS);
+define('TMP', sys_get_temp_dir() . DS);
+define('CACHE', TMP . 'cache' . DS);
+define('CORE_PATH', $root . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);
+
+Configure::write('debug', true);
+Cache::drop('_bedita_object_types_');
+Cache::drop('_bedita_core_');
+Cache::setConfig([
+    '_cake_core_' => [
+        'engine' => 'File',
+        'prefix' => 'cake_core_',
+        'serialize' => true,
+    ],
+    '_cake_model_' => [
+        'engine' => 'File',
+        'prefix' => 'cake_model_',
+        'serialize' => true,
+    ],
+    '_bedita_object_types_' => [
+        'className' => 'Null',
+    ],
+    '_bedita_core_' => [
+        'className' => 'Null',
+    ],
+]);
 
 ConnectionManager::setConfig('test', [
     'className' => Connection::class,
@@ -32,17 +74,22 @@ if (!TableRegistry::getTableLocator() instanceof TableLocator) {
 $now = FrozenTime::parse('2023-06-26T00:00:00Z');
 FrozenTime::setTestNow($now);
 FrozenDate::setTestNow($now);
-Configure::write('debug', true);
 
 // Fixate sessionid early on, as php7.2+
 // does not allow the sessionid to be set after stdout
 // has been written to.
-session_id('cli');
+//session_id('cli');
 
-TypeFactory::map('jsonobject', JsonObjectType::class);
+//TypeFactory::map('jsonobject', JsonObjectType::class);
 
-Cache::disable();
+//Router::reload();
+Security::setSalt('YlAPGwItcN6msaiuej76a6uyasdNTn3ikcO');
+
+// clear all before running tests
+TableRegistry::getTableLocator()->clear();
+Cache::clearAll();
+
 (new Migrator())->runMany([
-    ['plugin' => 'BEdita/Core', 'connection' => 'test'],
-    ['connection' => 'test'], // default migrations of this application
+    ['plugin' => 'BEdita/Core'],
+    ['connection' => 'test'],
 ]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,56 +7,20 @@ use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 
-/**
- * Test suite bootstrap for ElasticSearch.
- *
- * This function is used to find the location of CakePHP whether CakePHP
- * has been installed as a dependency of the plugin, or the plugin is itself
- * installed as a dependency of an application.
- */
-$findRoot = function ($root) {
-    do {
-        $lastRoot = $root;
-        $root = dirname($root);
-        if (is_dir($root . '/vendor/cakephp/cakephp')) {
-            return $root;
-        }
-    } while ($root !== $lastRoot);
-
-    throw new Exception('Cannot find the root of the application, unable to run tests');
-};
-$root = $findRoot(__FILE__);
-unset($findRoot);
-
-chdir($root);
-
-require_once $root . '/vendor/autoload.php';
-
-/**
- * Define fallback values for required constants and configuration.
- * To customize constants and configuration remove this require
- * and define the data required by your plugin here.
- */
-require_once $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
-
+require dirname(__DIR__) . '/vendor/autoload.php';
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';
 }
 
-// DebugKit skips settings these connection config if PHP SAPI is CLI / PHPDBG.
-// But since PagesControllerTest is run with debug enabled and DebugKit is loaded
-// in application, without setting up these config DebugKit errors out.
-ConnectionManager::setConfig('test_debug_kit', [
+ConnectionManager::setConfig('test', [
     'className' => Connection::class,
     'driver' => Sqlite::class,
-    'database' => dirname(__DIR__) . DS . 'tmp' . DS . 'debug_kit.sqlite',
+    'database' => dirname(__DIR__) . DS . 'tmp' . DS . 'test.sqlite',
     'encoding' => 'utf8',
     'cacheMetadata' => true,
     'quoteIdentifiers' => false,
 ]);
-
 ConnectionManager::alias('test', 'default');
-ConnectionManager::alias('test_debug_kit', 'debug_kit');
 
 if (!TableRegistry::getTableLocator() instanceof TableLocator) {
     TableRegistry::setTableLocator(new TableLocator());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -68,8 +68,8 @@ if (getenv('db_dsn')) {
         'cacheMetadata' => true,
         'quoteIdentifiers' => false,
     ]);
-    ConnectionManager::alias('test', 'default');
 }
+ConnectionManager::alias('test', 'default');
 
 if (!TableRegistry::getTableLocator() instanceof TableLocator) {
     TableRegistry::setTableLocator(new TableLocator());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,10 +3,15 @@ declare(strict_types=1);
 
 use BEdita\Core\ORM\Locator\TableLocator;
 use Cake\Cache\Cache;
+use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
+use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
+use Cake\I18n\FrozenDate;
+use Cake\I18n\FrozenTime;
 use Cake\ORM\TableRegistry;
+use Migrations\TestSuite\Migrator;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -23,4 +28,21 @@ ConnectionManager::alias('test', 'default');
 if (!TableRegistry::getTableLocator() instanceof TableLocator) {
     TableRegistry::setTableLocator(new TableLocator());
 }
+
+$now = FrozenTime::parse('2023-06-26T00:00:00Z');
+FrozenTime::setTestNow($now);
+FrozenDate::setTestNow($now);
+Configure::write('debug', true);
+
+// Fixate sessionid early on, as php7.2+
+// does not allow the sessionid to be set after stdout
+// has been written to.
+session_id('cli');
+
+TypeFactory::map('jsonobject', JsonObjectType::class);
+
 Cache::disable();
+(new Migrator())->runMany([
+    ['plugin' => 'BEdita/Core', 'connection' => 'test'],
+    ['connection' => 'test'], // default migrations of this application
+]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,8 +56,8 @@ Cache::setConfig([
         'className' => 'Null',
     ],
 ]);
+ConnectionManager::drop('test');
 if (getenv('db_dsn')) {
-    ConnectionManager::drop('test');
     ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
 } else {
     ConnectionManager::setConfig('test', [
@@ -89,11 +89,11 @@ FrozenDate::setTestNow($now);
 //Router::reload();
 Security::setSalt('YlAPGwItcN6msaiuej76a6uyasdNTn3ikcO');
 
-// clear all before running tests
-TableRegistry::getTableLocator()->clear();
-Cache::clearAll();
-
 (new Migrator())->runMany([
     ['plugin' => 'BEdita/Core'],
     ['connection' => 'test'],
 ]);
+
+// clear all before running tests
+TableRegistry::getTableLocator()->clear();
+Cache::clearAll();


### PR DESCRIPTION
This introduces:

 - `"bedita/core": "dev-refactor/v5/use-search-adapters"`: when [PR BE 2023](https://github.com/bedita/bedita/pull/2023) will be merged, this is gonna change
 - `ElasticSearchAdapter` (it requires https://github.com/bedita/bedita/pull/2023): it creates a temporary table and fill data into it, when the elastic search subquery returns data
 - php github workflow runs tests against different database types (`sqlite`, `mysql 5.7`, `mysql 8`, `postgresql`, `mariadb`)

Note:

 - `ElasticSearchAdapter::buildElasticSearchQuery` returns an empty array, for now. It will implemented soon in a separate activity + PR

Bonus: add manual release with release workflow (this is possible after https://github.com/bedita/github-workflows/pull/16)