### PR TITLE
Indexing & Querying

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,24 +34,30 @@ jobs:
         php:
           - '8.2'
         db:
-          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--entrypoint \"/bin/yes\" --health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:14", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
         elastic:
-          - 'opensearchproject/opensearch:2'
-          - 'opensearchproject/opensearch:1'
-          - 'elasticsearch:8.10.4'
-          - 'elasticsearch:7.17.14'
+          - '{"vendor": "OpenSearch 2", "image": "opensearchproject/opensearch:2", "dsn": "http://127.0.0.1:9200/?className=Cake\\ElasticSearch\\Datasource\\Connection&driver=opensearch", "options": "--health-cmd \"curl --fail --output /dev/null --silent http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - '{"vendor": "OpenSearch 1", "image": "opensearchproject/opensearch:1", "dsn": "http://127.0.0.1:9200/?className=Cake\\ElasticSearch\\Datasource\\Connection&driver=opensearch", "options": "--health-cmd \"curl --fail --output /dev/null --silent http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          # Disable HTTPS with "options" because the combination of openssl and curl versions breaks with this image (see https://github.com/php/php-src/issues/8369),
+          # and setting it in the service's "env" crashes OpenSearch with "unknown configuration" (maybe just ignore it?!)
+          - '{"vendor": "ElasticSearch 8", "image": "elasticsearch:8.11.0", "dsn": "http://elastic:admin@127.0.0.1:9200/?className=Cake\\ElasticSearch\\Datasource\\Connection&driver=elasticsearch&auth_type=basic", "options": "--env \"xpack.security.http.ssl.enabled=false\" --health-cmd \"curl --fail --output /dev/null --silent --user elastic:admin http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - '{"vendor": "ElasticSearch 7", "image": "elasticsearch:7.17.14", "dsn": "http://127.0.0.1:9200/?className=Cake\\ElasticSearch\\Datasource\\Connection&driver=elasticsearch", "options": "--health-cmd \"curl --fail --output /dev/null --silent http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
         include:
           - php: '8.2'
+            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--entrypoint \"/bin/yes\" --health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+            elastic: '{"vendor": "OpenSearch 2", "image": "opensearchproject/opensearch:2", "dsn": "http://127.0.0.1:9200/?className=Cake\\ElasticSearch\\Datasource\\Connection&driver=opensearch", "options": "--health-cmd \"curl --fail --output /dev/null --silent http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - php: '8.2'
             db: '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql5.7", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-            elastic: 'opensearchproject/opensearch:2'
+            elastic: '{"vendor": "OpenSearch 2", "image": "opensearchproject/opensearch:2", "dsn": "http://127.0.0.1:9200/?className=Cake\\ElasticSearch\\Datasource\\Connection&driver=opensearch", "options": "--health-cmd \"curl --fail --output /dev/null --silent http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - php: '8.2'
+            db: '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:14", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+            elastic: '{"vendor": "OpenSearch 2", "image": "opensearchproject/opensearch:2", "dsn": "http://127.0.0.1:9200/?className=Cake\\ElasticSearch\\Datasource\\Connection&driver=opensearch", "options": "--health-cmd \"curl --fail --output /dev/null --silent http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'
-      ELASTIC_VERSION: '${{ matrix.elastic }}'
+      ELASTIC_VERSION: '${{ fromJson(matrix.elastic).vendor }}'
       db_dsn: '${{ fromJson(matrix.db).dsn }}'
-      es_dsn: 'Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?driver=Cake\ElasticSearch\Datasource\Connection'
+      es_dsn: '${{ fromJson(matrix.elastic).dsn }}'
 
     services:
       db:
@@ -70,12 +76,18 @@ jobs:
           - '5432:5432'
         options: '${{ fromJson(matrix.db).options }}'
       elastic:
-        image: '${{ matrix.elastic }}'
+        image: '${{ fromJson(matrix.elastic).image }}'
         env:
           discovery.type: 'single-node'
+          # OpenSearch
+          DISABLE_INSTALL_DEMO_CONFIG: 'true'
+          DISABLE_SECURITY_PLUGIN: 'true'
+          # ElasticSearch
+          ELASTIC_PASSWORD: 'admin'
         ports:
           - '9200:9200'
           - '9300:9300'
+        options: '${{ fromJson(matrix.elastic).options }}'
 
     steps:
       - name: 'Checkout current revision'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -51,6 +51,7 @@ jobs:
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'
       ELASTIC_VERSION: '${{ matrix.elastic }}'
       db_dsn: '${{ fromJson(matrix.db).dsn }}'
+      es_dsn: 'Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?driver=Cake\ElasticSearch\Datasource\Connection'
 
     services:
       db:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,24 +33,27 @@ jobs:
       matrix:
         php:
           - '8.2'
+          - '8.1'
         db:
-          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql5.7", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:14", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+        elastic:
+          - 'opensearchproject/opensearch:2'
+          - 'opensearchproject/opensearch:1'
+          - 'elasticsearch:8'
+          - 'elasticsearch:7'
         include:
-          - php: '8.1'
-            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
-          - php: '8.1'
-            db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - php: '8.2'
-            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
-          - php: '8.2'
-            db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+            db: '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql5.7", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+            elastic: 'opensearchproject/opensearch:2'
+          - php: '8.1'
+            db: '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+            elastic: 'opensearchproject/opensearch:2'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'
+      ELASTIC_VERSION: '${{ matrix.elastic }}'
       db_dsn: '${{ fromJson(matrix.db).dsn }}'
 
     services:
@@ -69,6 +72,13 @@ jobs:
           - '3306:3306'
           - '5432:5432'
         options: '${{ fromJson(matrix.db).options }}'
+      elastic:
+        image: '${{ matrix.elastic }}'
+        env:
+          discovery.type: 'single-node'
+        ports:
+          - '9200:9200'
+          - '9300:9300'
 
     steps:
       - name: 'Checkout current revision'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,12 +16,12 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
     with:
-      php_versions: '["8.1","8.2"]'
+      php_versions: '["8.2"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
     with:
-      php_versions: '["8.1","8.2"]'
+      php_versions: '["8.2"]'
 
   unit:
     name: 'Run unit tests'
@@ -33,22 +33,18 @@ jobs:
       matrix:
         php:
           - '8.2'
-          - '8.1'
         db:
-          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--entrypoint \"/bin/yes\" --health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:14", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
         elastic:
           - 'opensearchproject/opensearch:2'
           - 'opensearchproject/opensearch:1'
-          - 'elasticsearch:8'
-          - 'elasticsearch:7'
+          - 'elasticsearch:8.10.4'
+          - 'elasticsearch:7.17.14'
         include:
           - php: '8.2'
             db: '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql5.7", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-            elastic: 'opensearchproject/opensearch:2'
-          - php: '8.1'
-            db: '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
             elastic: 'opensearchproject/opensearch:2'
     env:
       PHP_VERSION: '${{ matrix.php }}'
@@ -113,7 +109,7 @@ jobs:
         run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Dump Composer autoloader'
-        run: 'composer dump-autoload --classmap-authoritative --no-cache'
+        run: 'composer dump-autoload --optimize --no-cache'
 
       - name: 'Run PHPUnit with coverage'
         run: 'vendor/bin/phpunit --coverage-clover=clover.xml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ on:
         default: 'patch'
         type: choice
         options:
-        - patch
-        - minor
-        - major
+          - patch
+          - minor
+          - major
 jobs:
   release-job:
     uses: bedita/github-workflows/.github/workflows/release.yml@v1

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "cakephp/cakephp": "^4.4.1",
         "cakephp/elastic-search": "^3.4",
-        "bedita/core": "dev-feat/v5/search-adapters-soft-delete-status"
+        "bedita/core": "dev-feat/v5/search-adapters"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "cakephp/cakephp": "^4.4.1",
         "cakephp/elastic-search": "^3.4",
-        "bedita/core": "dev-refactor/v5/use-search-adapters"
+        "bedita/core": "dev-feat/v5/search-adapters-soft-delete-status"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
@@ -48,8 +48,8 @@
             "@test",
             "@cs-check"
         ],
-        "cs-check": "vendor/bin/phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
-        "cs-fix": "vendor/bin/phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
+        "cs-check": "vendor/bin/phpcs",
+        "cs-fix": "vendor/bin/phpcbf",
         "test": "vendor/bin/phpunit --colors=always",
         "stan": "vendor/bin/phpstan analyse"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "cakephp/cakephp": "^4.4.1",
         "cakephp/elastic-search": "^3.4",
         "bedita/core": "dev-feat/v5/search-adapters",
-        "ruflin/elastica": "^7.1"
+        "ruflin/elastica": "^7.1",
+        "elasticsearch/elasticsearch": "^7.10"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "php": "^8.1",
         "cakephp/cakephp": "^4.4.1",
         "cakephp/elastic-search": "^3.4",
-        "bedita/core": "dev-feat/v5/search-adapters"
+        "bedita/core": "dev-feat/v5/search-adapters",
+        "ruflin/elastica": "^7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,4 +13,10 @@
     <rule ref="CakePHP">
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes" />
     </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
+        <properties>
+            <property name="shortNullable" value="no"/>
+        </properties>
+    </rule>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^If condition is always true\\.$#"
+			message: "#^Using nullsafe method call on non\\-nullable type Elastica\\\\Result\\. Use \\-\\> instead\\.$#"
 			count: 1
 			path: src/Model/Document/Search.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: src/Model/Document/Search.php
-
-		-
-			message: "#^Access to an undefined property Cake\\\\Datasource\\\\EntityInterface::\\$id\\.$#"
+			message: "#^Access to an undefined property Cake\\\\Datasource\\\\EntityInterface\\:\\:\\$id\\.$#"
 			count: 1
 			path: src/Model/Index/SearchIndex.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,6 @@ parameters:
 			path: src/Model/Document/Search.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
+			message: "#^Access to an undefined property Cake\\\\Datasource\\\\EntityInterface::\\$id\\.$#"
 			count: 1
 			path: src/Model/Index/SearchIndex.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,16 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: src/Model/Document/Search.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Model/Document/Search.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: src/Model/Index/SearchIndex.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,8 +2,6 @@ includes:
     - phpstan-baseline.neon
 parameters:
   phpVersion: 80212
-  bootstrapFiles:
-    - tests/bootstrap.php
   paths:
     - src
     - tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 includes:
     - phpstan-baseline.neon
 parameters:
+  phpVersion: 80212
   bootstrapFiles:
     - tests/bootstrap.php
   paths:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,5 @@
+includes:
+    - phpstan-baseline.neon
 parameters:
   bootstrapFiles:
     - tests/bootstrap.php

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -45,7 +45,7 @@ class ElasticSearchAdapter extends BaseAdapter
      *
      * @return \BEdita\ElasticSearch\Model\Index\AdapterCompatibleInterface&\Cake\ElasticSearch\Index
      */
-    protected function getIndex(): Index&AdapterCompatibleInterface
+    public function getIndex(): Index&AdapterCompatibleInterface
     {
         if (!isset($this->index)) {
             $index = $this->getConfig('index', 'BEdita/ElasticSearch.Search');

--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 namespace BEdita\ElasticSearch\Adapter;
 
 use BEdita\Core\Search\BaseAdapter;
+use BEdita\ElasticSearch\Model\Document\Search;
+use BEdita\ElasticSearch\Model\Index\AdapterCompatibleInterface;
 use Cake\Database\Connection;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\FactoryLocator;
+use Cake\ElasticSearch\Index;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
@@ -17,11 +21,53 @@ use Cake\Utility\Security;
 use Exception;
 use Psr\Log\LogLevel;
 use RuntimeException;
+use UnexpectedValueException;
 
+/**
+ * ElasticSearch adapter for BEdita search.
+ */
 class ElasticSearchAdapter extends BaseAdapter
 {
     use LocatorAwareTrait;
     use LogTrait;
+
+    protected const MAX_RESULTS = 1000;
+
+    /**
+     * Index instance.
+     *
+     * @var \Cake\ElasticSearch\Index&\BEdita\ElasticSearch\Model\Index\AdapterCompatibleInterface
+     */
+    protected Index&AdapterCompatibleInterface $index;
+
+    /**
+     * Get index instance for search index.
+     *
+     * @return \BEdita\ElasticSearch\Model\Index\AdapterCompatibleInterface&\Cake\ElasticSearch\Index
+     */
+    protected function getIndex(): Index&AdapterCompatibleInterface
+    {
+        if (!isset($this->index)) {
+            $index = $this->getConfig('index', 'BEdita/ElasticSearch.Search');
+            if (is_string($index)) {
+                /** @var \Cake\ElasticSearch\Datasource\IndexLocator $locator */
+                $locator = FactoryLocator::get('ElasticSearch');
+                $index = $locator->get($index);
+            }
+            if (!$index instanceof Index || !$index instanceof AdapterCompatibleInterface) {
+                throw new UnexpectedValueException(sprintf(
+                    'Search index must be an instance of %s that implements %s interface, got %s',
+                    Index::class,
+                    AdapterCompatibleInterface::class,
+                    get_debug_type($index),
+                ));
+            }
+
+            $this->index = $index;
+        }
+
+        return $this->index;
+    }
 
     /**
      * @inheritDoc
@@ -38,6 +84,7 @@ class ElasticSearchAdapter extends BaseAdapter
      */
     public function indexResource(EntityInterface $entity, string $operation): void
     {
+        $this->getIndex()->reindex($entity, $operation);
     }
 
     /**
@@ -45,11 +92,17 @@ class ElasticSearchAdapter extends BaseAdapter
      *
      * @param string $text The search text
      * @param array $options The options
-     * @return array
+     * @return array<array{id: string, score: float}>
      */
     protected function buildElasticSearchQuery(string $text, array $options): array
     {
-        return [];
+        return $this->getIndex()
+            ->find('query', ['query' => $text] + $options)
+            ->select(['_id', '_score'])
+            ->limit(static::MAX_RESULTS)
+            ->all()
+            ->map(fn (Search $doc): array => ['id' => $doc->id, 'score' => $doc->score()])
+            ->toList();
     }
 
     /**
@@ -63,7 +116,6 @@ class ElasticSearchAdapter extends BaseAdapter
     protected function buildQuery(Query $query, string $text, array $options): Query
     {
         $results = $this->buildElasticSearchQuery($text, $options);
-
         if (count($results) === 0) {
             // Nothing found. No results should be returned. Add a contradiction to the `WHERE` clause.
             return $query->where(new ComparisonExpression('1', '1', 'integer', '<>'));
@@ -81,11 +133,10 @@ class ElasticSearchAdapter extends BaseAdapter
         return $query
             ->innerJoin(
                 $tempTable->getTable(),
-                // @phpstan-ignore-next-line
-                fn (QueryExpression $exp): QueryExpression => $exp->equalFields(
+                (new QueryExpression())->equalFields(
                     $tempTable->aliasField('id'),
                     $query->getRepository()->aliasField('id'),
-                )
+                ),
             )
             ->orderDesc($tempTable->aliasField('score'));
     }

--- a/src/Command/CreateIndexCommand.php
+++ b/src/Command/CreateIndexCommand.php
@@ -34,7 +34,7 @@ class CreateIndexCommand extends Command
      *
      * @throws \Exception Error loading adapter from registry
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int|null
     {
         $registry = new SearchRegistry();
         $adapters = array_keys((array)Configure::read('Search.adapters'));

--- a/src/Command/CreateIndexCommand.php
+++ b/src/Command/CreateIndexCommand.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ElasticSearch\Command;
+
+use BEdita\Core\Search\SearchRegistry;
+use BEdita\ElasticSearch\Adapter\ElasticSearchAdapter;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Configure;
+
+/**
+ * Utility command to create the configured ElasticSearch index.
+ */
+class CreateIndexCommand extends Command
+{
+    /**
+     * @inheritDoc
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return parent::buildOptionParser($parser)
+            ->setDescription('Create ElasticSearch indices for configured adapters.')
+            ->addOption('adapters', [
+                'help' => 'Create indices only for these adapters (comma-separated list).',
+                'required' => false,
+            ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \Exception Error loading adapter from registry
+     */
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $registry = new SearchRegistry();
+        $adapters = array_keys((array)Configure::read('Search.adapters'));
+        if ($args->hasOption('adapters')) {
+            $adapters = explode(',', (string)$args->getOption('adapters'));
+        }
+
+        foreach ($adapters as $name) {
+            $config = (array)Configure::read(sprintf('Search.adapters.%s', $name));
+            if (empty($config)) {
+                $io->warning(sprintf('Missing configuration for adapter "%s", skipping index creation', $name));
+
+                continue;
+            }
+
+            $adapter = $registry->load($name, $config);
+            if (!$adapter instanceof ElasticSearchAdapter) {
+                $io->warning(sprintf(
+                    'Adapter "%s" is not an instance of %s, skipping index creation',
+                    $name,
+                    ElasticSearchAdapter::class,
+                ));
+
+                continue;
+            }
+
+            $index = $adapter->getIndex();
+            if (!$index->create()) {
+                $io->error(sprintf('Error creating index "%s" for adapter "%s"', $index->getName(), $name));
+
+                continue;
+            }
+
+            $io->success(sprintf('Created index "%s" for adapter "%s"', $index->getName(), $name));
+        }
+
+        return static::CODE_SUCCESS;
+    }
+}

--- a/src/Model/Document/ObjectSearch.php
+++ b/src/Model/Document/ObjectSearch.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ElasticSearch\Model\Document;
+
+/**
+ *  Base searchable document representing a BEdita object.
+ *
+ * @property numeric-string $id Object ID.
+ * @property string $uname Object unique name.
+ * @property string $type Object type.
+ * @property 'on'|'draft'|'off' $status Object status.
+ * @property bool $deleted Object deletion status.
+ * @property \DateTimeInterface|null $publish_start Publication start.
+ * @property \DateTimeInterface|null $publish_end Publication end.
+ * @property string $title Object title.
+ * @property string $description Object description.
+ * @property string $body Object body.
+ */
+class ObjectSearch extends Search
+{
+}

--- a/src/Model/Document/Search.php
+++ b/src/Model/Document/Search.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ElasticSearch\Model\Document;
+
+use Cake\ElasticSearch\Document;
+
+/**
+ * Base searchable document.
+ *
+ * @property int|string $id Document ID.
+ */
+class Search extends Document
+{
+    /**
+     * Returns the score of this document as returned by ElasticSearch after search.
+     *
+     * @return float|null
+     */
+    public function score(): float|null
+    {
+        if ($this->_result) {
+            return $this->_result->getScore();
+        }
+
+        return null;
+    }
+}

--- a/src/Model/Document/Search.php
+++ b/src/Model/Document/Search.php
@@ -16,13 +16,10 @@ class Search extends Document
      * Returns the score of this document as returned by ElasticSearch after search.
      *
      * @return float|null
+     * @codeCoverageIgnore
      */
     public function score(): float|null
     {
-        if ($this->_result) {
-            return $this->_result->getScore();
-        }
-
-        return null;
+        return $this->_result?->getScore();
     }
 }

--- a/src/Model/Index/AdapterCompatibleInterface.php
+++ b/src/Model/Index/AdapterCompatibleInterface.php
@@ -21,6 +21,34 @@ interface AdapterCompatibleInterface
     public function findQuery(Query $query, array $options): Query;
 
     /**
+     * Create the index.
+     *
+     * @param array $arguments Body for the request to ElasticSearch's API
+     * @param array $options Query parameters for the request to ElasticSearch's API
+     * @return bool
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
+     */
+    public function create(array $arguments = [], array $options = []): bool;
+
+    /**
+     * Update properties mappings, if possible.
+     *
+     * @param array $properties New properties configuration
+     * @return bool
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html
+     */
+    public function updateProperties(array $properties = []): bool;
+
+    /**
+     * Update analysis settings, if possible.
+     *
+     * @param array $analysis New analysis configuration
+     * @return bool
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
+     */
+    public function updateAnalysis(array $analysis = []): bool;
+
+    /**
      * Reindex an entity.
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity to be reindexed.

--- a/src/Model/Index/AdapterCompatibleInterface.php
+++ b/src/Model/Index/AdapterCompatibleInterface.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ElasticSearch\Model\Index;
+
+use Cake\Datasource\EntityInterface;
+use Cake\ElasticSearch\Query;
+
+/**
+ * Interface for ElasticSearch indices classes to reindex an entity.
+ */
+interface AdapterCompatibleInterface
+{
+    /**
+     * Perform full text search.
+     *
+     * @param \Cake\ElasticSearch\Query $query Query object instance.
+     * @param array{query: string} $options Search options.
+     * @return \Cake\ElasticSearch\Query
+     */
+    public function findQuery(Query $query, array $options): Query;
+
+    /**
+     * Reindex an entity.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity to be reindexed.
+     * @param string $operation Operation.
+     * @return void
+     */
+    public function reindex(EntityInterface $entity, string $operation): void;
+}

--- a/src/Model/Index/IndexTrait.php
+++ b/src/Model/Index/IndexTrait.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 namespace BEdita\ElasticSearch\Model\Index;
 
 use Cake\Datasource\EntityInterface;
+use Cake\ElasticSearch\Datasource\Connection;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Elastica\Document;
 use Elastica\Exception\NotFoundException;
 
 trait IndexTrait
 {
+    /**
+     * Returns the ElasticSearch connection instance for this index.
+     *
+     * @return \Cake\ElasticSearch\Datasource\Connection
+     */
+    abstract public function getConnection(): Connection;
+
     /**
      * Retrieve a document from the index.
      *

--- a/src/Model/Index/IndexTrait.php
+++ b/src/Model/Index/IndexTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace BEdita\ElasticSearch\Model\Index;
 
 use Cake\Datasource\EntityInterface;
-use Cake\ElasticSearch\Datasource\Connection;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Elastica\Document;
 use Elastica\Exception\NotFoundException;
@@ -15,8 +14,9 @@ trait IndexTrait
      * Returns the ElasticSearch connection instance for this index.
      *
      * @return \Cake\ElasticSearch\Datasource\Connection
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      */
-    abstract public function getConnection(): Connection;
+    abstract public function getConnection();
 
     /**
      * Retrieve a document from the index.

--- a/src/Model/Index/IndexTrait.php
+++ b/src/Model/Index/IndexTrait.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ElasticSearch\Model\Index;
+
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\Exception\PersistenceFailedException;
+use Elastica\Document;
+use Elastica\Exception\NotFoundException;
+
+trait IndexTrait
+{
+    /**
+     * Retrieve a document from the index.
+     *
+     * @param string $primaryKey Document ID.
+     * @param array $options Array of options.
+     * @return \Cake\Datasource\EntityInterface
+     */
+    abstract public function get(string $primaryKey, array $options = []): EntityInterface;
+
+    /**
+     * Persist a document to the index.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Document.
+     * @param array $options Array of options.
+     * @return \Cake\Datasource\EntityInterface|false
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     */
+    abstract public function save(EntityInterface $entity, array $options);
+
+    /**
+     * Delete a document from the index.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Document.
+     * @param array $options Array of options.
+     * @return bool
+     */
+    abstract public function delete(EntityInterface $entity, array $options): bool;
+
+    /**
+     * Retrieve a document from the index if exists, or `null` on failure.
+     *
+     * @see \Cake\ElasticSearch\Index::get()
+     * @param string $primaryKey Document ID.
+     * @param array $options Array of options.
+     * @return \Cake\Datasource\EntityInterface|null
+     */
+    public function getIfExists(string $primaryKey, array $options = []): EntityInterface|null
+    {
+        try {
+            return $this->get($primaryKey, $options);
+        } catch (NotFoundException) {
+            return null;
+        }
+    }
+
+    /**
+     * Persist a document to the index, or throw an exception upon failure.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Document.
+     * @param array $options
+     * @return \Cake\Datasource\EntityInterface
+     */
+    public function saveOrFail(EntityInterface $entity, array $options = []): EntityInterface
+    {
+        if ($this->save($entity, $options) === false) {
+            throw new PersistenceFailedException($entity, ['save']);
+        }
+
+        return $entity;
+    }
+
+    /**
+     * Delete a document from the index, or throw an exception upon failure.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Document.
+     * @param array $options Array of options.
+     * @return void
+     */
+    public function deleteOrFail(EntityInterface $entity, array $options): void
+    {
+        if ($this->delete($entity, $options) === false) {
+            throw new PersistenceFailedException($entity, ['delete']);
+        }
+    }
+
+    /**
+     * Update a single field on an existing document.
+     *
+     * @param string $primaryKey Document ID.
+     * @param string $field Name of field to update.
+     * @param mixed $value New value.
+     * @return bool Success.
+     */
+    public function set(string $primaryKey, string $field, mixed $value): bool
+    {
+        $esIndex = $this->getConnection()->getIndex($this->getName());
+        $document = new Document($primaryKey, [$field => $value]);
+        $response = $esIndex->updateDocument($document);
+
+        return $response->isOk();
+    }
+}

--- a/src/Model/Index/ObjectSearchIndex.php
+++ b/src/Model/Index/ObjectSearchIndex.php
@@ -1,0 +1,165 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ElasticSearch\Model\Index;
+
+use BEdita\Core\Model\Entity\ObjectEntity;
+use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
+use Cake\ElasticSearch\Query;
+use Cake\ElasticSearch\QueryBuilder;
+use Cake\I18n\FrozenTime;
+use Cake\Log\Log;
+use Cake\ORM\Exception\PersistenceFailedException;
+use Cake\Validation\Validator;
+use Elastica\Query\AbstractQuery;
+use InvalidArgumentException;
+
+/**
+ * Base search index for BEdita objects in ElasticSearch.
+ */
+class ObjectSearchIndex extends SearchIndex
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function validationDefault(Validator $validator): Validator
+    {
+        return $validator
+            ->notEmptyString('uname')
+            ->requirePresence('uname', 'create')
+
+            ->notEmptyString('type')
+            ->requirePresence('type', 'create')
+
+            ->inList('status', ['on', 'draft', 'off'])
+            ->requirePresence('status', 'create')
+
+            ->boolean('deleted')
+
+            ->dateTime('publish_start')
+            ->allowEmptyDateTime('publish_start')
+
+            ->dateTime('publish_end')
+            ->allowEmptyDateTime('publish_end')
+
+            ->scalar('title')
+            ->allowEmptyString('title')
+
+            ->scalar('description')
+            ->allowEmptyString('description')
+
+            ->scalar('body')
+            ->allowEmptyString('body');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reindex(EntityInterface $entity, string $operation): void
+    {
+        if (!$entity instanceof ObjectEntity) {
+            Log::warning(sprintf(
+                '%s index is supposed to be used only with sub-types of "%s", got "%s" instead',
+                static::class,
+                ObjectEntity::class,
+                get_debug_type($entity),
+            ));
+            parent::reindex($entity, $operation);
+
+            return;
+        }
+
+        switch ($operation) {
+            case 'softDelete':
+            case 'softDeleteRestore':
+                $id = (string)$entity->id;
+                if (!$this->set($id, 'deleted', $entity->deleted)) {
+                    throw new PersistenceFailedException($this->get($id), ['set']);
+                }
+                break;
+
+            default:
+                parent::reindex($entity, $operation);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param \Cake\ElasticSearch\Query $query Query object instance.
+     * @param array{query: string, type?: string|string[]} $options Search options.
+     * @return \Cake\ElasticSearch\Query
+     */
+    public function findQuery(Query $query, array $options): Query
+    {
+        if (isset($options['type'])) {
+            $query = $query->find('type', ['type' => $options['type']]);
+        }
+
+        return $query
+            ->find('available')
+            ->queryMust(
+                fn (QueryBuilder $builder): AbstractQuery => $builder
+                    ->simpleQueryString(['title', 'description', 'body'], $options['query']),
+            );
+    }
+
+    /**
+     * Find "available" documents, i.e. respective of deletion, status and publication constraints.
+     *
+     * @param \Cake\ElasticSearch\Query $query Query object instance.
+     * @return \Cake\ElasticSearch\Query
+     */
+    protected function findAvailable(Query $query): Query
+    {
+        return $query->andWhere(function (QueryBuilder $builder): AbstractQuery {
+            $conditions = [
+                // Filter objects that are not deleted.
+                $builder->term('deleted', 'false'),
+            ];
+
+            // Filter by object status.
+            $statusLevel = Configure::read('Status.level', 'all');
+            if ($statusLevel === 'on') {
+                $conditions[] = $builder->term('status', 'on');
+            } elseif ($statusLevel === 'draft') {
+                $conditions[] = $builder->terms('status', ['on', 'draft']);
+            }
+
+            // Filter by publication date.
+            if ((bool)Configure::read('Publish.checkDate', false)) {
+                $now = FrozenTime::now();
+
+                $conditions[] = $builder
+                    ->or($builder->not($builder->exists('publish_start')), $builder->lte('publish_start', $now))
+                    ->setMinimumShouldMatch(1);
+                $conditions[] = $builder
+                    ->or($builder->not($builder->exists('publish_end')), $builder->gte('publish_end', $now))
+                    ->setMinimumShouldMatch(1);
+            }
+
+            return $builder->and(...$conditions);
+        });
+    }
+
+    /**
+     * Filter by object type.
+     *
+     * @param \Cake\ElasticSearch\Query $query Query object instance.
+     * @param array{type: string|string[]} $options Finder options.
+     * @return \Cake\ElasticSearch\Query
+     */
+    protected function findType(Query $query, array $options): Query
+    {
+        if (empty($options['type'])) {
+            throw new InvalidArgumentException('Missing or empty `type` option');
+        }
+
+        return $query->andWhere(
+            fn (QueryBuilder $builder): AbstractQuery => $builder->terms('type', (array)$options['type']),
+        );
+    }
+}

--- a/src/Model/Index/ObjectSearchIndex.php
+++ b/src/Model/Index/ObjectSearchIndex.php
@@ -21,6 +21,21 @@ use InvalidArgumentException;
 class ObjectSearchIndex extends SearchIndex
 {
     /**
+     * @inheritDoc
+     */
+    protected static array $_properties = [
+        'uname' => ['type' => 'text'],
+        'type' => ['type' => 'text'],
+        'status' => ['type' => 'text'],
+        'deleted' => ['type' => 'boolean'],
+        'publish_start' => ['type' => 'date'],
+        'publish_end' => ['type' => 'date'],
+        'title' => ['type' => 'text'],
+        'description' => ['type' => 'text'],
+        'body' => ['type' => 'text'],
+    ];
+
+    /**
      * {@inheritDoc}
      *
      * @codeCoverageIgnore

--- a/src/Model/Index/SearchIndex.php
+++ b/src/Model/Index/SearchIndex.php
@@ -88,14 +88,14 @@ class SearchIndex extends Index implements AdapterCompatibleInterface
      */
     public function create(array $arguments = [], array $options = []): bool
     {
-        if (empty(Hash::get($arguments, 'mappings.properties')) && !empty(self::$_properties)) {
-            $arguments = Hash::insert($arguments, 'mappings.properties', self::$_properties);
+        if (empty(Hash::get($arguments, 'mappings.properties')) && !empty(static::$_properties)) {
+            $arguments = Hash::insert($arguments, 'mappings.properties', static::$_properties);
         }
-        if (empty(Hash::get($arguments, 'settings.analysis')) && !empty(self::$_analysis)) {
-            $arguments = Hash::insert($arguments, 'settings.analysis', self::$_analysis);
+        if (empty(Hash::get($arguments, 'settings.analysis')) && !empty(static::$_analysis)) {
+            $arguments = Hash::insert($arguments, 'settings.analysis', static::$_analysis);
         }
 
-        $esIndex = $this->getConnection()->getIndex();
+        $esIndex = $this->getConnection()->getIndex($this->getName());
         $response = $esIndex->create($arguments, $options);
         if (!$response->isOk()) {
             Log::error(sprintf(

--- a/src/Model/Index/SearchIndex.php
+++ b/src/Model/Index/SearchIndex.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ElasticSearch\Model\Index;
+
+use Cake\Database\DriverInterface;
+use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\EntityInterface;
+use Cake\ElasticSearch\Index;
+use Cake\ElasticSearch\Query;
+use Cake\ElasticSearch\QueryBuilder;
+use Cake\Log\Log;
+use Cake\Utility\Inflector;
+use Elastica\Query\AbstractQuery;
+
+/**
+ * Base search index for ElasticSearch.
+ */
+class SearchIndex extends Index implements AdapterCompatibleInterface
+{
+    use IndexTrait;
+
+    /**
+     * Returns the index name.
+     *
+     * If it isn't set, it is constructed from v
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        if ($this->_name === null) {
+            $defaultName = $this->getDefaultName();
+            if ($defaultName !== null) {
+                $this->_name = $defaultName;
+            }
+        }
+
+        return parent::getName();
+    }
+
+    /**
+     * Returns the default index name, constructed from the default collection schema and the alias for the index.
+     *
+     * @return string|null
+     */
+    protected function getDefaultName(): string|null
+    {
+        $driver = ConnectionManager::get('default')->getDriver();
+        if (!$driver instanceof DriverInterface) {
+            return null;
+        }
+
+        $prefix = $driver->schema();
+        $suffix = Inflector::underscore($this->getAlias());
+        if (empty($prefix) || empty($suffix)) {
+            return null;
+        }
+
+        return $prefix . '_' . $suffix;
+    }
+
+    /**
+     * Delete a document from the index knowing its ID, or throw an exception upon failure.
+     *
+     * @param string $id Document ID.
+     * @param array $options Options to be passed to {@see \Cake\ElasticSearch\Index::delete()} method.
+     * @return void
+     */
+    public function deleteByIdOrFail(string $id, array $options = []): void
+    {
+        $document = $this->getIfExists($id);
+        if ($document === null) {
+            return;
+        }
+
+        $this->deleteOrFail($document, $options);
+    }
+
+    /**
+     * Prepare data for indexing. This method may be overridden by implementations to customize indexed fields.
+     *
+     * If `null` is returned, entity indexing is skipped (and an entity with such ID is removed
+     * from index if already present).
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity to be indexed.
+     * @return array<string, mixed>|null
+     */
+    protected function prepareData(EntityInterface $entity): array|null
+    {
+        return $entity->toArray();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reindex(EntityInterface $entity, string $operation): void
+    {
+        $id = (string)$entity->id;
+        switch ($operation) {
+            case 'edit':
+                $data = $this->prepareData($entity);
+                if ($data === null) {
+                    $this->deleteByIdOrFail($id);
+                } else {
+                    $document = $this->patchEntity($this->getIfExists($id) ?: $this->newEmptyEntity(), $data);
+                    $this->saveOrFail($document);
+                }
+                break;
+
+            case 'delete':
+                $this->deleteByIdOrFail($id);
+                break;
+
+            default:
+                Log::warning(sprintf('Unknown operation on ElasticSearch reindex: %s', $operation));
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findQuery(Query $query, array $options): Query
+    {
+        return $query->queryMust(
+            fn (QueryBuilder $builder): AbstractQuery => $builder->simpleQueryString('title', $options['query']),
+        );
+    }
+}

--- a/src/Model/Index/SearchIndex.php
+++ b/src/Model/Index/SearchIndex.php
@@ -10,8 +10,12 @@ use Cake\ElasticSearch\Index;
 use Cake\ElasticSearch\Query;
 use Cake\ElasticSearch\QueryBuilder;
 use Cake\Log\Log;
+use Cake\Log\LogTrait;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Elastica\Query\AbstractQuery;
+use Elasticsearch\Endpoints\Indices\PutMapping;
+use Elasticsearch\Endpoints\Indices\PutSettings;
 
 /**
  * Base search index for ElasticSearch.
@@ -19,6 +23,25 @@ use Elastica\Query\AbstractQuery;
 class SearchIndex extends Index implements AdapterCompatibleInterface
 {
     use IndexTrait;
+    use LogTrait;
+
+    /**
+     * Map of fields and their configuration (type, analyzer, normalizer, etc.).
+     *
+     * This property must be overridden by implementations to customize the mappings used by the index.
+     *
+     * @var array
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-params.html
+     */
+    protected static array $_properties = [];
+
+    /**
+     * Settings for the text analysis (define/configure analyzers, tokenizers, filters, etc.).
+     *
+     * @var array
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/configure-text-analysis.html
+     */
+    protected static array $_analysis = [];
 
     /**
      * Returns the index name.
@@ -58,6 +81,108 @@ class SearchIndex extends Index implements AdapterCompatibleInterface
         }
 
         return $prefix . '_' . $suffix;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(array $arguments = [], array $options = []): bool
+    {
+        if (empty(Hash::get($arguments, 'mappings.properties')) && !empty(self::$_properties)) {
+            $arguments = Hash::insert($arguments, 'mappings.properties', self::$_properties);
+        }
+        if (empty(Hash::get($arguments, 'settings.analysis')) && !empty(self::$_analysis)) {
+            $arguments = Hash::insert($arguments, 'settings.analysis', self::$_analysis);
+        }
+
+        $esIndex = $this->getConnection()->getIndex();
+        $response = $esIndex->create($arguments, $options);
+        if (!$response->isOk()) {
+            Log::error(sprintf(
+                'Error creating index "%s": %s',
+                $this->getName(),
+                $response->getErrorMessage(),
+            ));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateProperties(array $properties = []): bool
+    {
+        if (empty($properties)) {
+            $properties = self::$_properties;
+        }
+
+        $endpoint = new PutMapping();
+        $endpoint->setBody(compact('properties'));
+        $esIndex = $this->getConnection()->getIndex();
+        $response = $esIndex->requestEndpoint($endpoint);
+        if (!$response->isOk()) {
+            Log::error(sprintf(
+                'Error updating index "%s" mappings: %s',
+                $this->getName(),
+                $response->getErrorMessage(),
+            ));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateAnalysis(array $analysis = []): bool
+    {
+        if (empty($analysis)) {
+            $analysis = self::$_analysis;
+        }
+
+        // Adding new analyzers requires temporarily closing the index
+        $esIndex = $this->getConnection()->getIndex();
+        $response = $esIndex->close();
+        if (!$response->isOk()) {
+            Log::error(sprintf(
+                'Error closing the index "%s" before updating analysis settings: %s',
+                $this->getName(),
+                $response->getErrorMessage(),
+            ));
+
+            return false;
+        }
+
+        $endpoint = new PutSettings();
+        $endpoint->setBody(compact('analysis'));
+        $response = $esIndex->requestEndpoint($endpoint);
+        if (!$response->isOk()) {
+            Log::error(sprintf(
+                'Error updating index "%s" settings: %s',
+                $this->getName(),
+                $response->getErrorMessage(),
+            ));
+
+            return false;
+        }
+
+        $response = $esIndex->open();
+        if (!$response->isOk()) {
+            Log::error(sprintf(
+                'Error opening the index "%s" after updating analysis settings: %s',
+                $this->getName(),
+                $response->getErrorMessage(),
+            ));
+
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Model/Index/SearchIndex.php
+++ b/src/Model/Index/SearchIndex.php
@@ -23,7 +23,7 @@ class SearchIndex extends Index implements AdapterCompatibleInterface
     /**
      * Returns the index name.
      *
-     * If it isn't set, it is constructed from v
+     * If it isn't set, it is constructed from the default collection schema and the alias for the index.
      *
      * @return string
      */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,10 +4,23 @@ declare(strict_types=1);
 namespace BEdita\ElasticSearch;
 
 use Cake\Core\BasePlugin;
+use Cake\Core\PluginApplicationInterface;
+use Cake\ElasticSearch\Plugin as ElasticSearchPlugin;
 
 /**
  * Plugin for BEdita ElasticSearch
  */
 class Plugin extends BasePlugin
 {
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function bootstrap(PluginApplicationInterface $app): void
+    {
+        parent::bootstrap($app);
+
+        $app->addPlugin(ElasticSearchPlugin::class);
+    }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace BEdita\ElasticSearch;
 
+use BEdita\ElasticSearch\Command\CreateIndexCommand;
+use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\ElasticSearch\Plugin as ElasticSearchPlugin;
@@ -22,5 +24,14 @@ class Plugin extends BasePlugin
         parent::bootstrap($app);
 
         $app->addPlugin(ElasticSearchPlugin::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function console(CommandCollection $commands): CommandCollection
+    {
+        return parent::console($commands)
+            ->add('elastic:createIndex', CreateIndexCommand::class);
     }
 }

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 namespace BEdita\ElasticSearch\Test\TestCase\Adapter;
 
 use BEdita\ElasticSearch\Adapter\ElasticSearchAdapter;
+use BEdita\ElasticSearch\Model\Index\AdapterCompatibleInterface;
+use BEdita\ElasticSearch\Model\Index\SearchIndex;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\FactoryLocator;
+use Cake\ElasticSearch\Index;
+use Cake\ElasticSearch\TestSuite\TestCase;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
-use Cake\TestSuite\TestCase;
+use Exception;
 use ReflectionClass;
+use UnexpectedValueException;
 
 /**
  * {@see BEdita\ElasticSearch\Adapter\ElasticSearchAdapter} Test Case
@@ -23,17 +28,58 @@ class ElasticSearchAdapterTest extends TestCase
      * @inheritDoc
      */
     protected $fixtures = [
-        'plugin.BEdita/Core.ObjectTypes',
-        'plugin.BEdita/Core.Objects',
+//        'plugin.BEdita/Core.ObjectTypes',
+//        'plugin.BEdita/Core.Objects',
     ];
 
     /**
-     * @inheritDoc
+     * Data provider for {@see ElasticSearchAdapterTest::testGetIndex()} test case.
+     *
+     * @return array<string, array{\Cake\ElasticSearch\Index|Exception, string|\Cake\ElasticSearch\Index}>
      */
-    public function setUp(): void
+    public function getIndexProvider(): array
     {
-        TableRegistry::getTableLocator()->clear();
-        parent::setUp();
+        /** @var \Cake\ElasticSearch\Datasource\IndexLocator $locator */
+        $locator = FactoryLocator::get('ElasticSearch');
+
+        $index = new SearchIndex();
+        $locator->set('IndexProviderTest', $index);
+
+        return [
+            'string' => [$index, 'IndexProviderTest'],
+            'object' => [$index, $index],
+            'index does not implement interface' => [
+                new UnexpectedValueException('Search index must be an instance of Cake\ElasticSearch\Index that implements BEdita\ElasticSearch\Model\Index\AdapterCompatibleInterface interface, got Cake\ElasticSearch\Index'),
+                new Index(),
+            ],
+        ];
+    }
+
+    /**
+     * Test {@see ElasticSearchAdapter::getIndex()} method.
+     *
+     * @param \Cake\ElasticSearch\Index|Exception $expected Expected outcome.
+     * @param string|\Cake\ElasticSearch\Index $index Index configuration.
+     * @return void
+     * @dataProvider getIndexProvider()
+     * @covers ::getIndex()
+     */
+    public function testGetIndex(Index|Exception $expected, string|Index $index): void
+    {
+        if ($expected instanceof Exception) {
+            $this->expectExceptionObject($expected);
+        }
+
+        $adapter = new class extends ElasticSearchAdapter {
+            public function getIndex(): Index&AdapterCompatibleInterface
+            {
+                return parent::getIndex();
+            }
+        };
+        $adapter->setConfig(compact('index'));
+
+        $actual = $adapter->getIndex();
+        static::assertSame($expected, $actual);
     }
 
     /**

--- a/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
+++ b/tests/TestCase/Adapter/ElasticSearchAdapterTest.php
@@ -114,8 +114,8 @@ class ElasticSearchAdapterTest extends TestCase
             protected function buildElasticSearchQuery(string $text, array $options): array
             {
                 return [
-                    ['id' => 1, 'score' => 1.0],
-                    ['id' => 2, 'score' => 0.5],
+                    ['id' => '1', 'score' => 1.0],
+                    ['id' => '2', 'score' => 0.5],
                 ];
             }
         };

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 use BEdita\Core\ORM\Locator\TableLocator;
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
-use Cake\Database\Connection as DbConnection;
+use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\FactoryLocator;
-use Cake\ElasticSearch\Datasource\Connection as EsConnection;
+use Cake\ElasticSearch\Datasource\Connection as ElasticConnection;
 use Cake\ElasticSearch\Datasource\IndexLocator;
 use Cake\ElasticSearch\TestSuite\Fixture\MappingGenerator;
 use Cake\ORM\TableRegistry;
@@ -29,28 +29,13 @@ $root = $findRoot(__FILE__);
 unset($findRoot);
 chdir($root);
 
-require_once 'vendor/cakephp/cakephp/src/basics.php';
 require_once 'vendor/autoload.php';
-
-define('ROOT', $root . DS . 'tests' . DS . 'test_app' . DS);
-define('TMP', sys_get_temp_dir() . DS);
-define('CACHE', TMP . 'cache' . DS);
-define('CORE_PATH', $root . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);
+require_once 'vendor/cakephp/cakephp/tests/bootstrap.php';
 
 Configure::write('debug', true);
 Cache::drop('_bedita_object_types_');
 Cache::drop('_bedita_core_');
 Cache::setConfig([
-    '_cake_core_' => [
-        'engine' => 'File',
-        'prefix' => 'cake_core_',
-        'serialize' => true,
-    ],
-    '_cake_model_' => [
-        'engine' => 'File',
-        'prefix' => 'cake_model_',
-        'serialize' => true,
-    ],
     '_bedita_object_types_' => [
         'className' => 'Null',
     ],
@@ -58,49 +43,49 @@ Cache::setConfig([
         'className' => 'Null',
     ],
 ]);
+
 ConnectionManager::drop('test');
-if (getenv('db_dsn')) {
-    ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
-} else {
-    ConnectionManager::setConfig('test', [
-        'className' => DbConnection::class,
-        'driver' => Sqlite::class,
-        'database' => dirname(__DIR__) . DS . 'tmp' . DS . 'test.sqlite',
-        'encoding' => 'utf8',
-        'cacheMetadata' => true,
-        'quoteIdentifiers' => false,
-    ]);
-}
+ConnectionManager::setConfig('test', [
+    'className' => Connection::class,
+    'driver' => Sqlite::class,
+    'database' => dirname(__DIR__) . DS . 'tmp' . DS . 'test.sqlite',
+    'encoding' => 'utf8',
+    'cacheMetadata' => true,
+    'quoteIdentifiers' => false,
+
+    'url' => env('db_dsn'),
+]);
 ConnectionManager::alias('test', 'default');
 
-if (getenv('es_dsn')) {
-    ConnectionManager::setConfig('test-es', ['url' => getenv('es_dsn')]);
-} else {
-    ConnectionManager::setConfig('test-es', [
-        'className' => EsConnection::class,
-        'driver' => EsConnection::class,
-        'host' => '127.0.0.1',
-        'port' => 9200,
-    ]);
-}
+require_once 'vendor/bedita/core/config/bootstrap.php';
 
-if (!TableRegistry::getTableLocator() instanceof TableLocator) {
-    TableRegistry::setTableLocator(new TableLocator());
-}
+ConnectionManager::setDsnClassMap(['elasticsearch' => ElasticConnection::class, 'opensearch' => ElasticConnection::class]);
+ConnectionManager::drop('test_elastic');
+ConnectionManager::setConfig('test_elastic', [
+    'className' => ElasticConnection::class,
+    'host' => '127.0.0.1',
+    'port' => 9200,
 
-Security::setSalt('YlAPGwItcN6msaiuej76a6uyasdNTn3ikcO');
+    'curl' => [
+        // Trust any TLS certificate ElasticSearch/OpenSearch may present.
+        // This is INSECURE but for unit test purposes should be ok.
+        CURLOPT_SSL_VERIFYPEER => false,
+    ],
+
+    'url' => env('es_dsn'),
+]);
+
+Security::setSalt(str_pad('TEST SECURITY SALT', 32, '\0'));
 
 (new Migrator())->runMany([
     ['plugin' => 'BEdita/Core'],
     ['connection' => 'test'],
 ]);
 
-$schema = new MappingGenerator('./tests/mappings.php', 'test-es');
-$schema->reload();
+(new MappingGenerator('./tests/mappings.php', 'test_elastic'))->reload();
 
-$indexLocator = new IndexLocator();
-FactoryLocator::add('ElasticSearch', $indexLocator);
+FactoryLocator::add('ElasticSearch', new IndexLocator());
 
 // clear all before running tests
-TableRegistry::getTableLocator()->clear();
+TableRegistry::setTableLocator(new TableLocator());
 Cache::clearAll();

--- a/tests/mappings.php
+++ b/tests/mappings.php
@@ -16,4 +16,10 @@ return [
             'body' => ['type' => 'text'],
         ],
     ],
+    [
+        'name' => 'search',
+        'mapping' => [
+            'title' => ['type' => 'text'],
+        ],
+    ],
 ];

--- a/tests/mappings.php
+++ b/tests/mappings.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+return [
+    [
+        'name' => 'objects',
+        'mapping' => [
+            'uname' => ['type' => 'text'],
+            'type' => ['type' => 'text'],
+            'status' => ['type' => 'text'],
+            'deleted' => ['type' => 'boolean'],
+            'publish_start' => ['type' => 'date'],
+            'publish_end' => ['type' => 'date'],
+            'title' => ['type' => 'text'],
+            'description' => ['type' => 'text'],
+            'body' => ['type' => 'text'],
+        ],
+    ],
+];


### PR DESCRIPTION
This PR implements indexing and basic querying.

The [cakephp/elasticsearch](https://github.com/cakephp/elasticsearch) plugin has been used. Two basic indexes are included (one for generic entities, the other specific for BEdita Objects), but it is possible to extend the base functionality by implementing your own `Index` class both for customising the indexed document and for building your own search query.

### Example

```php
class MyAppIndex extends ObjectSearchIndex
{
    protected function getDefaultName(): string
    {
        return 'my_app'; // Name of ElasticSearch index (by default it uses SQL database/schema name).
    }

    protected function prepareData(EntityInterface $entity): array|null
    {
        if (!$entity instanceof ObjectEntity || $entity->deleted) {
            return null; // Do not include deleted objects in our app index.
        }

        return parent::prepareData($entity) + [
            'title_reverse' => strrev($entity->title),
        ];
    }

    public function findQuery(Query $query, array $options): Query
    {
        if (isset($options['type'])) {
            // The `type` finder from `ObjectSearchIndex` filters by `object_type` (exact match).
            $query = $query->find('type', ['type' => $options['type']]);
        }

        // This is the finder invoked by the adapter.
        return $query
            // The `available` finder from `ObjectSearchIndex` filter by `deleted`, `status` and `publish_*` fields, respecting current application settings.
            ->find('available')

            // Full text search and other conditions go here.
            ->queryMust(fn (QueryBuilder $builder): AbstractQuery => $builder->simpleQueryString(
                // Customize fields for full-text search:
                ['title^2', 'description', 'body', 'title_reverse^5'],
                $options['query'],
            ));
    }
}
```

In `config/app.php`:

```php
    'Search' => [
        'adapters' => [
            // ...
            'my-app' => [
                'className' => \BEdita\ElasticSearch\Adapter\ElasticSearchAdapter::class,
                'index' => 'MyApp',
            ],
        ],
    ],
```