### PR TITLE
feat: pass options to index when building instance with locator

### DIFF
--- a/src/Adapter/ElasticSearchAdapter.php
+++ b/src/Adapter/ElasticSearchAdapter.php
@@ -52,7 +52,7 @@ class ElasticSearchAdapter extends BaseAdapter
             if (is_string($index)) {
                 /** @var \Cake\ElasticSearch\Datasource\IndexLocator $locator */
                 $locator = FactoryLocator::get('ElasticSearch');
-                $index = $locator->get($index);
+                $index = $locator->get($index, (array)$this->getConfig('options'));
             }
             if (!$index instanceof Index || !$index instanceof AdapterCompatibleInterface) {
                 throw new UnexpectedValueException(sprintf(


### PR DESCRIPTION
This PR add the possibility to pass options to the index constructor when the adapter first fetches it.