### PR TITLE
Ensure document ID is always a string

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,14 @@
 parameters:
 	ignoreErrors:
 		-
+			identifier: missingType.iterableValue
+
+		-
 			message: "#^Using nullsafe method call on non\\-nullable type Elastica\\\\Result\\. Use \\-\\> instead\\.$#"
 			count: 1
 			path: src/Model/Document/Search.php
 
 		-
 			message: "#^Access to an undefined property Cake\\\\Datasource\\\\EntityInterface\\:\\:\\$id\\.$#"
-			count: 1
+			count: 2
 			path: src/Model/Index/SearchIndex.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,3 @@ parameters:
     - src
     - tests
   level: 9
-  checkMissingIterableValueType: false

--- a/src/Model/Index/SearchIndex.php
+++ b/src/Model/Index/SearchIndex.php
@@ -213,7 +213,7 @@ class SearchIndex extends Index implements AdapterCompatibleInterface
      */
     protected function prepareData(EntityInterface $entity): array|null
     {
-        return $entity->toArray();
+        return ['id' => (string)$entity->id] + $entity->toArray();
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue with the default adapter, and ensures that the entity ID is always cast to a string before being passed to Elastica ORM.