### PR TITLE
Index only fields configured in properties

### DIFF
--- a/src/Model/Index/ObjectSearchIndex.php
+++ b/src/Model/Index/ObjectSearchIndex.php
@@ -114,6 +114,24 @@ class ObjectSearchIndex extends SearchIndex
     }
 
     /**
+     * Prepare data for indexing. This method may be overridden by implementations to customize indexed fields.
+     *
+     * If `null` is returned, entity indexing is skipped (and an entity with such ID is removed
+     * from index if already present).
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity to be indexed.
+     * @return array<string, mixed>|null
+     */
+    protected function prepareData(EntityInterface $entity): array|null
+    {
+        if (!$entity instanceof ObjectEntity) {
+            return null;
+        }
+
+        return ['id' => (string)$entity->id] + $entity->extract(array_keys(static::$_properties));
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @param \Cake\ElasticSearch\Query $query Query object instance.


### PR DESCRIPTION
For objects index, include only fields configured in `static::$_properties` by default.

This is necessary in order to avoid errors when the type inferred by ElasticSearch/OpenSearch automatically is not the correct type.