### PR TITLE
fix: allow empty `deleted` property

### DIFF
--- a/src/Model/Index/ObjectSearchIndex.php
+++ b/src/Model/Index/ObjectSearchIndex.php
@@ -54,6 +54,7 @@ class ObjectSearchIndex extends SearchIndex
             ->requirePresence('status', 'create')
 
             ->boolean('deleted')
+            ->allowEmptyString('deleted')
 
             ->dateTime('publish_start')
             ->allowEmptyDateTime('publish_start')


### PR DESCRIPTION
This PR adds a validation rule to allow empty `deleted` property in `ObjectSearchIndex`.